### PR TITLE
Update runmake.sh

### DIFF
--- a/runmake.sh
+++ b/runmake.sh
@@ -13,7 +13,7 @@ OLD_PATH=$PATH
 
 # Set our host and target architectures
 if [ -z "${STEAM_RUNTIME_HOST_ARCH}" ]; then
-    STEAM_RUNTIME_HOST_ARCH=$(dpkg --print-architecture)
+    STEAM_RUNTIME_HOST_ARCH=$(uname -m)
 fi
 
 if [ -z "$STEAM_RUNTIME_TARGET_ARCH" ]; then


### PR DESCRIPTION
Replace dpkg with uname so GES is more system agnostic and will build on non-debian linux systems.
